### PR TITLE
Fix: checkout failing because polar doesn't support passing subscript…

### DIFF
--- a/packages/backend/convex/subscriptions.ts
+++ b/packages/backend/convex/subscriptions.ts
@@ -15,13 +15,11 @@ import schema from "./schema";
 const createCheckout = async ({
   customerEmail,
   productPriceId,
-  successUrl,
-  subscriptionId,
+  successUrl
 }: {
   customerEmail: string;
   productPriceId: string;
   successUrl: string;
-  subscriptionId?: string;
 }) => {
   const polar = new Polar({
     server: "sandbox",
@@ -30,8 +28,7 @@ const createCheckout = async ({
   const result = await polar.checkouts.create({
     productPriceId,
     successUrl,
-    customerEmail,
-    subscriptionId,
+    customerEmail
   });
   return result;
 };
@@ -98,8 +95,7 @@ export const getProOnboardingCheckoutUrl = action({
     const checkout = await createCheckout({
       customerEmail: user.email,
       productPriceId: price.polarId,
-      successUrl: `${env.SITE_URL}/settings/billing`,
-      subscriptionId: user.subscription?.polarId,
+      successUrl: `${env.SITE_URL}/settings/billing`
     });
     return checkout.url;
   },


### PR DESCRIPTION
…ion id anymore.

I removed passing subscription id in polar checkout create because it causes an error that says polar doesn't support passsing subscription id anymore



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
