### PR TITLE
feat(config): add TypeScript path alias for backend imports

### DIFF
--- a/packages/backend/convex/tsconfig.json
+++ b/packages/backend/convex/tsconfig.json
@@ -18,7 +18,11 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+
+    "paths": {
+      "@v1/backend/*": ["../../packages/backend/*"]
+    }
   },
   "include": ["./**/*"],
   "exclude": ["./_generated"]


### PR DESCRIPTION
Add path alias '@v1/backend/*' to convex tsconfig.json to enable cleaner imports from the backend package. This replaces verbose relative paths with a consistent alias pattern.

Before:
import { env } from "../../../../packages/backend/convex/env"

After: 
import { env } from "@v1/backend/convex/env"

Benefits:
- Cleaner and more maintainable imports
- Consistent import pattern across codebase
- Better support for monorepo package structure

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
